### PR TITLE
[#43] 회원 도메인의 컨트롤러에서 엑세스 토큰 상수 분리

### DIFF
--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/ApiConstant.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/ApiConstant.java
@@ -5,6 +5,8 @@ public class ApiConstant {
     public static final String PASSWORD_VALUE = "비밀번호";
     public static final String PASSWORD_CONFIRM_VALUE = "비밀번호 확인";
     public static final String PASSWORD_EXAMPLE = "Abc1!2@34";
+    public static final String ACCESS_TOKEN_VALUE = "엑세스 토큰 값";
+    public static final String ACCESS_TOKEN_EXAMPLE = "accessToken";
 
     public static final String PRINCIPAL_POINTCUT
             = "isAuthenticated() and (( #userId == principal.username ) or hasRole('ROLE_ADMIN'))";

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/EmailUpdateRequest.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/EmailUpdateRequest.java
@@ -5,14 +5,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_EXAMPLE;
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_VALUE;
+import static personal.jeuksipay.member.adapter.in.web.ApiConstant.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class EmailUpdateRequest {
-    private static final String ACCESS_TOKEN_VALUE = "엑세스 토큰 값";
-    private static final String ACCESS_TOKEN_EXAMPLE = "accessToken";
     private static final String EMAIL_TO_CHANGE_VALUE = "변경할 이메일 주소";
     private static final String EMAIL_TO_CHANGE_EXAMPLE = "abcde@abc.com";
 

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/MemberDeleteRequest.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/MemberDeleteRequest.java
@@ -6,16 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_EXAMPLE;
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_VALUE;
+import static personal.jeuksipay.member.adapter.in.web.ApiConstant.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
 public class MemberDeleteRequest {
-    public static final String ACCESS_TOKEN_VALUE = "엑세스 토큰 값";
-    public static final String ACCESS_TOKEN_EXAMPLE = "accessToken";
-
     @ApiModelProperty(value = PASSWORD_VALUE, example = PASSWORD_EXAMPLE)
     private String password;
 

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/PasswordUpdateRequest.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/PasswordUpdateRequest.java
@@ -5,14 +5,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_EXAMPLE;
+import static personal.jeuksipay.member.adapter.in.web.ApiConstant.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PasswordUpdateRequest {
     private static final String CURRENT_PASSWORD_VALUE = "현재 비밀번호";
-    private static final String ACCESS_TOKEN_VALUE = "엑세스 토큰 값";
-    private static final String ACCESS_TOKEN_EXAMPLE = "accessToken";
 
     private static final String PASSWORD_TO_CHANGE_VALUE = "변경할 비밀번호";
     private static final String PASSWORD_TO_CHANGE_CONFIRM_VALUE = "변경할 비밀번호 확인";

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/PhoneUpdateRequest.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/request/PhoneUpdateRequest.java
@@ -5,14 +5,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_EXAMPLE;
-import static personal.jeuksipay.member.adapter.in.web.ApiConstant.PASSWORD_VALUE;
+import static personal.jeuksipay.member.adapter.in.web.ApiConstant.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PhoneUpdateRequest {
-    private static final String ACCESS_TOKEN_VALUE = "엑세스 토큰 값";
-    private static final String ACCESS_TOKEN_EXAMPLE = "accessToken";
     private static final String PHONE_TO_CHANGE_VALUE = "변경할 전화번호";
     private static final String PHONE_TO_CHANGE_EXAMPLE = "01012345679";
 


### PR DESCRIPTION
## resolve #43

## 변경사항
- 중복되는 엑세스 토큰 관련 상수를 컨트롤러에서 분리