### PR TITLE
[#46] 회원 도메인의 포맷 정리

### DIFF
--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/controller/AuthenticationController.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/controller/AuthenticationController.java
@@ -11,7 +11,7 @@ import personal.jeuksipay.member.adapter.in.web.mapper.MemberRequestToCommandMap
 import personal.jeuksipay.member.adapter.in.web.request.SignInRequest;
 import personal.jeuksipay.member.adapter.in.web.response.SignInResponse;
 import personal.jeuksipay.member.application.port.in.AuthenticationResult;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 import personal.jeuksipay.member.application.port.in.usecase.AuthenticationUseCase;
 
 @WebAdapter
@@ -35,7 +35,7 @@ public class AuthenticationController {
     @PostMapping("/login")
     public ResponseEntity<SignInResponse> signInMember
             (@RequestBody @ApiParam(value = SIGN_IN_FORM) SignInRequest signInRequest) {
-        signInCommand signInCommand = MemberRequestToCommandMapper.mapToCommand(signInRequest);
+        SignInCommand signInCommand = MemberRequestToCommandMapper.mapToCommand(signInRequest);
         AuthenticationResult authenticationResult = authenticationUseCase.signInMember(signInCommand);
 
         return ResponseEntity.status(HttpStatus.OK).body(SignInResponse.from(authenticationResult));

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/controller/UpdateMemberController.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/controller/UpdateMemberController.java
@@ -36,9 +36,9 @@ public class UpdateMemberController {
     private static final String UPDATE_ADDRESS_FORM = "주소 변경 양식";
 
     private static final String UPDATE_EMAIL = "이메일 주소 변경";
-    private static final String UPDATE_UPDATE_EMAIL_DESCRIPTION
+    private static final String UPDATE_EMAIL_DESCRIPTION
             = "비밀번호와 변경할 이메일 주소를 입력해 이메일 주소를 수정할 수 있습니다.";
-    private static final String UPDATE_UPDATE_EMAIL_FORM = "이메일 주소 변경 양식";
+    private static final String UPDATE_EMAIL_FORM = "이메일 주소 변경 양식";
 
     private static final String UPDATE_PHONE = "전화번호 변경";
     private static final String UPDATE_PHONE_DESCRIPTION = "비밀번호와 변경할 전화번호를 입력해 전화번호를 수정할 수 있습니다.";
@@ -60,11 +60,11 @@ public class UpdateMemberController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @ApiOperation(value = UPDATE_EMAIL, notes = UPDATE_UPDATE_EMAIL_DESCRIPTION)
+    @ApiOperation(value = UPDATE_EMAIL, notes = UPDATE_EMAIL_DESCRIPTION)
     @PreAuthorize(PRINCIPAL_POINTCUT)
     @PatchMapping("/email")
     public ResponseEntity<Void> updateEmail
-            (@RequestBody @ApiParam(value = UPDATE_UPDATE_EMAIL_FORM) EmailUpdateRequest emailUpdateRequest) {
+            (@RequestBody @ApiParam(value = UPDATE_EMAIL_FORM) EmailUpdateRequest emailUpdateRequest) {
         EmailUpdateCommand emailUpdateCommand = MemberRequestToCommandMapper.mapToCommand(emailUpdateRequest);
         updateMemberUseCase.updateEmail(emailUpdateCommand);
 

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/mapper/MemberRequestToCommandMapper.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/mapper/MemberRequestToCommandMapper.java
@@ -18,8 +18,8 @@ public class MemberRequestToCommandMapper {
                 .build();
     }
 
-    public static signInCommand mapToCommand(SignInRequest signInRequest) {
-        return new signInCommand(signInRequest.getEmailOrUsername(), signInRequest.getPassword());
+    public static SignInCommand mapToCommand(SignInRequest signInRequest) {
+        return new SignInCommand(signInRequest.getEmailOrUsername(), signInRequest.getPassword());
     }
 
     public static EmailUpdateCommand mapToCommand(EmailUpdateRequest emailUpdateRequest) {

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/vault/VaultAdapter.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/vault/VaultAdapter.java
@@ -15,7 +15,7 @@ public class VaultAdapter {
         VaultKeyValueOperations ops = vaultTemplate
                 .opsForKeyValue("kv-v1/data/encrypt", VaultKeyValueOperationsSupport.KeyValueBackend.KV_2);
         String key = (String) ops.get("dbkey").getData().get("key");
-        this.encryptor = new AESProvider(key);
+        encryptor = new AESProvider(key);
     }
 
     public String encrypt(String plainText) {

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/controller/AuthenticationControllerTest.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/controller/AuthenticationControllerTest.java
@@ -14,7 +14,7 @@ import personal.jeuksipay.member.adapter.in.web.request.SignInRequest;
 import personal.jeuksipay.member.adapter.in.web.security.CustomAuthenticationEntryPoint;
 import personal.jeuksipay.member.adapter.out.security.JwtTokenProvider;
 import personal.jeuksipay.member.application.port.in.AuthenticationResult;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 import personal.jeuksipay.member.application.port.in.usecase.AuthenticationUseCase;
 import personal.jeuksipay.member.domain.Member;
 import personal.jeuksipay.member.domain.wrapper.Roles;
@@ -60,7 +60,7 @@ class AuthenticationControllerTest {
         when(member.getRoles()).thenReturn(Roles.from(List.of(ROLE_GENERAL_USER.toString())));
         AuthenticationResult authenticationResult = AuthenticationResult.from(member, "accessToken", "refreshToken");
 
-        when(authenticationUseCase.signInMember(any(signInCommand.class))).thenReturn(authenticationResult);
+        when(authenticationUseCase.signInMember(any(SignInCommand.class))).thenReturn(authenticationResult);
 
         // when, then
         mockMvc.perform(post("/members/login")

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/controller/DeleteMemberControllerTest.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/controller/DeleteMemberControllerTest.java
@@ -7,42 +7,38 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import personal.jeuksipay.member.adapter.in.web.request.EmailUpdateRequest;
 import personal.jeuksipay.member.adapter.in.web.request.MemberDeleteRequest;
 import personal.jeuksipay.member.adapter.in.web.security.CustomAuthenticationEntryPoint;
 import personal.jeuksipay.member.adapter.out.security.JwtTokenProvider;
 import personal.jeuksipay.member.application.port.in.usecase.DeleteMemberUseCase;
-import personal.jeuksipay.member.application.port.in.usecase.UpdateMemberUseCase;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static personal.jeuksipay.member.testutil.MemberTestConstant.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static personal.jeuksipay.member.testutil.MemberTestConstant.PASSWORD1;
+import static personal.jeuksipay.member.testutil.MemberTestConstant.TOKEN_VALUE1;
 
 @ActiveProfiles("test")
 @WebMvcTest(controllers = DeleteMemberController.class)
 class DeleteMemberControllerTest {
-        @Autowired
-        private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-        @Autowired
-        private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-        @MockBean
-        private DeleteMemberUseCase deleteMemberUseCase;
+    @MockBean
+    private DeleteMemberUseCase deleteMemberUseCase;
 
-        @MockBean
-        private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
 
-        @MockBean
-        private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @DisplayName("비밀번호를 입력해 회원 탈퇴할 수 있다.")
     @Test

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/aop/MemberLoggingAspect.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/aop/MemberLoggingAspect.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 import personal.jeuksipay.common.application.aop.MemoryUtil;
 import personal.jeuksipay.member.application.port.in.command.SignUpCommand;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 
 import static personal.jeuksipay.common.application.aop.LogMessage.PERFORMANCE_MEASUREMENT;
 
@@ -57,7 +57,7 @@ public class MemberLoggingAspect {
     }
 
     @Around(SIGN_IN_POINTCUT)
-    public Object logAroundForSignInCommand(ProceedingJoinPoint joinPoint, signInCommand signInCommand) throws Throwable {
+    public Object logAroundForSignInCommand(ProceedingJoinPoint joinPoint, SignInCommand signInCommand) throws Throwable {
         log.info(SIGN_IN_START,
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), signInCommand.getEmailOrUsername());

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/command/SignInCommand.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/command/SignInCommand.java
@@ -3,11 +3,11 @@ package personal.jeuksipay.member.application.port.in.command;
 import lombok.Getter;
 
 @Getter
-public class signInCommand {
+public class SignInCommand {
     private final String emailOrUsername;
     private final String password;
 
-    public signInCommand(String emailOrUsername, String password) {
+    public SignInCommand(String emailOrUsername, String password) {
         this.emailOrUsername = emailOrUsername;
         this.password = password;
     }

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/usecase/AuthenticationUseCase.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/usecase/AuthenticationUseCase.java
@@ -1,10 +1,10 @@
 package personal.jeuksipay.member.application.port.in.usecase;
 
 import personal.jeuksipay.member.application.port.in.AuthenticationResult;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 
 public interface AuthenticationUseCase {
-    AuthenticationResult signInMember(signInCommand signInCommand);
+    AuthenticationResult signInMember(SignInCommand signInCommand);
 
     String issueNewAccessToken(String refreshToken);
 }

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/AuthenticationService.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/AuthenticationService.java
@@ -16,8 +16,8 @@ import personal.jeuksipay.member.domain.RefreshToken;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
-@RequiredArgsConstructor
 @UseCase
+@RequiredArgsConstructor
 public class AuthenticationService implements AuthenticationUseCase {
     private final AuthenticationPort authenticationPort;
     private final FindMemberPort findMemberPort;

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/AuthenticationService.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/AuthenticationService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import personal.jeuksipay.common.application.UseCase;
 import personal.jeuksipay.member.application.port.in.AuthenticationResult;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 import personal.jeuksipay.member.application.port.in.usecase.AuthenticationUseCase;
 import personal.jeuksipay.member.application.port.out.AuthenticationPort;
 import personal.jeuksipay.member.application.port.out.FindMemberPort;
@@ -27,7 +27,7 @@ public class AuthenticationService implements AuthenticationUseCase {
 
     @Override
     @Transactional(isolation = READ_COMMITTED, timeout = 15)
-    public AuthenticationResult signInMember(signInCommand signInCommand) {
+    public AuthenticationResult signInMember(SignInCommand signInCommand) {
         Member signedUpMember = findMemberPort.findMemberByEmailOrUsername(signInCommand.getEmailOrUsername());
         passwordValidator.validatePassword(signedUpMember.getPassword(), signInCommand.getPassword());
 

--- a/member-service/member-application/src/test/java/personal/jeuksipay/member/application/service/AuthenticationServiceTest.java
+++ b/member-service/member-application/src/test/java/personal/jeuksipay/member/application/service/AuthenticationServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import personal.jeuksipay.member.application.port.in.AuthenticationResult;
-import personal.jeuksipay.member.application.port.in.command.signInCommand;
+import personal.jeuksipay.member.application.port.in.command.SignInCommand;
 import personal.jeuksipay.member.application.port.out.AuthenticationPort;
 import personal.jeuksipay.member.application.port.out.FindMemberPort;
 import personal.jeuksipay.member.application.port.out.FindRefreshTokenPort;
@@ -43,6 +43,7 @@ class AuthenticationServiceTest {
 
     @Mock
     private FindRefreshTokenPort findRefreshTokenPort;
+
     @Mock
     private PasswordEncoder passwordEncoder;
 
@@ -53,7 +54,7 @@ class AuthenticationServiceTest {
     @Test
     void signInMember() {
         // given
-        signInCommand signInCommand = new signInCommand(EMAIL, PASSWORD1);
+        SignInCommand signInCommand = new SignInCommand(EMAIL, PASSWORD1);
         Member member = MemberTestObjectFactory.createMember(
                 ID_EXAMPLE, EMAIL, USERNAME, PASSWORD1, passwordEncoder,
                 FULL_NAME, PHONE, List.of(ROLE_GENERAL_USER.toString())

--- a/member-service/member-application/src/test/java/personal/jeuksipay/member/application/service/DeleteMemberServiceTest.java
+++ b/member-service/member-application/src/test/java/personal/jeuksipay/member/application/service/DeleteMemberServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import personal.jeuksipay.member.application.port.in.command.MemberDeleteCommand;
 import personal.jeuksipay.member.application.port.out.AuthenticationPort;
 import personal.jeuksipay.member.application.port.out.DeleteMemberPort;


### PR DESCRIPTION
## resolve #46

## 변경사항
- import문 정리
- 들여쓰기 정리
- UPDATE_EMAIL_DESCRIPTION 상수의 중복된 UPDATE 문구 제거
- signInCommand 클래스의 첫 글자를 대문자로 수정
- VaultAdapter 클래스의 생성자에서 필드 참조 시 현재 인스턴스에 대한 불필요한 참조 문구 제거