### PR TITLE
[#48] Google OAuth2 적용 

### DIFF
--- a/member-service/member-adapters/build.gradle
+++ b/member-service/member-adapters/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // vault
     implementation group: 'org.springframework.vault', name: 'spring-vault-core', version: '2.3.3'

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/cookie/CookieManager.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/in/web/cookie/CookieManager.java
@@ -1,0 +1,50 @@
+package personal.jeuksipay.member.adapter.in.web.cookie;
+
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+
+public class CookieManager {
+    public static void addCookie(HttpServletResponse response, String nameToAdd, String value, int maxAge) {
+        Cookie cookie = new Cookie(nameToAdd, value);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String nameToDelete) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (isCookieToDelete(nameToDelete, cookie.getName())) {
+                deleteTargetCookie(cookie);
+                response.addCookie(cookie);
+            }
+        }
+    }
+
+    private static boolean isCookieToDelete(String nameToDelete, String cookieName) {
+        return nameToDelete.equals(cookieName);
+    }
+
+    private static void deleteTargetCookie(Cookie cookie) {
+        cookie.setValue("");
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberJpaEntity.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberJpaEntity.java
@@ -29,21 +29,23 @@ public class MemberJpaEntity {
     private Email email;
 
     @Convert(converter = Username.UsernameConverter.class)
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(unique = true, length = 50)
     private Username username;
 
     @Convert(converter = Password.PasswordConverter.class)
-    @Column(nullable = false)
     @JsonIgnore
     private Password password;
 
+    @Convert(converter = OauthName.OauthNameConverter.class)
+    private OauthName oauthName;
+
     @Convert(converter = FullName.FullNameConverter.class)
-    @Column(nullable = false, length = 30)
+    @Column(length = 30)
     @JsonIgnore
     private FullName fullName;
 
     @Convert(converter = Phone.PhoneConverter.class)
-    @Column(nullable = false, unique = true, length = 40)
+    @Column(unique = true, length = 40)
     @JsonIgnore
     private Phone phone;
 
@@ -58,13 +60,14 @@ public class MemberJpaEntity {
     private LocalDateTime lastLoggedInAt;
 
     @Builder
-    private MemberJpaEntity(Long id, Email email, Username username, Password password,
+    private MemberJpaEntity(Long id, Email email, Username username, Password password, OauthName oauthName,
                             FullName fullName, Phone phone, Address address, Roles roles,
                             LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime lastLoggedInAt) {
         this.id = id;
         this.email = email;
         this.username = username;
         this.password = password;
+        this.oauthName = oauthName;
         this.fullName = fullName;
         this.phone = phone;
         this.address = address;
@@ -77,6 +80,7 @@ public class MemberJpaEntity {
     public static MemberJpaEntity from(Member member, CryptoProvider cryptoProvider) {
         Email emailToEncrypt = member.getEmail();
         Username usernameToEncrypt = member.getUsername();
+        OauthName oauthNameToEncrypt = member.getOauthName();
         FullName fullNameToEncrypt = member.getFullName();
         Phone phoneToEncrypt = member.getPhone();
         Address addressToEncrypt = member.getAddress();
@@ -85,6 +89,7 @@ public class MemberJpaEntity {
                 .id(member.getId())
                 .email(emailToEncrypt.encrypt(cryptoProvider))
                 .username(usernameToEncrypt.encrypt(cryptoProvider))
+                .oauthName(oauthNameToEncrypt == null ? null : oauthNameToEncrypt.encrypt(cryptoProvider))
                 .password(member.getPassword())
                 .fullName(fullNameToEncrypt.encrypt(cryptoProvider))
                 .phone(phoneToEncrypt.encrypt(cryptoProvider))
@@ -93,6 +98,16 @@ public class MemberJpaEntity {
                 .createdAt(member.getCreatedAt())
                 .modifiedAt(member.getModifiedAt())
                 .lastLoggedInAt(member.getLastLoggedInAt())
+                .build();
+    }
+
+    public static MemberJpaEntity fromOauth(Member member, CryptoProvider cryptoProvider) {
+        Email emailToEncrypt = member.getEmail();
+        OauthName oauthNameToEncrypt = member.getOauthName();
+
+        return MemberJpaEntity.builder()
+                .email(emailToEncrypt.encrypt(cryptoProvider))
+                .oauthName(oauthNameToEncrypt.encrypt(cryptoProvider))
                 .build();
     }
 

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
@@ -36,6 +36,12 @@ public class MemberPersistenceAdapter implements SignUpPort, FindMemberPort, Upd
     }
 
     @Override
+    public void saveOauthMember(Member member) {
+        MemberJpaEntity encryptedMemberJpaEntity = MemberJpaEntity.fromOauth(member, cryptoProvider);
+        memberRepository.save(encryptedMemberJpaEntity);
+    }
+
+    @Override
     public Member findMemberById(Long memberId) {
         MemberJpaEntity memberJpaEntity = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(MEMEBER_ID_NOT_FOUND_EXCEPTION + memberId));
@@ -52,6 +58,17 @@ public class MemberPersistenceAdapter implements SignUpPort, FindMemberPort, Upd
                 : memberRepository.findByUsername(Username.of(emailOrUsername).encrypt(cryptoProvider))
                 .orElseThrow(() -> new EntityNotFoundException
                         (USERNAME_NOT_FOUND_EXCEPTION + emailOrUsername));
+
+        memberJpaEntity.updateLoginTime();
+
+        return MemberJpaEntityToDomainMapper.mapToDomainEntity(memberJpaEntity, cryptoProvider);
+    }
+
+    @Override
+    public Member findMemberByEmail(String oauthEmail) {
+        MemberJpaEntity memberJpaEntity = memberRepository.findByEmail(Email.of(oauthEmail).encrypt(cryptoProvider))
+                .orElseThrow(() -> new EntityNotFoundException
+                        (EMAIL_NOT_FOUND_EXCEPTION + oauthEmail));
 
         memberJpaEntity.updateLoginTime();
 
@@ -81,8 +98,8 @@ public class MemberPersistenceAdapter implements SignUpPort, FindMemberPort, Upd
 
     @Override
     public void updateMember(Member member) {
-        MemberJpaEntity memberJpaEntity = MemberJpaEntity.from(member, cryptoProvider);
-        memberRepository.save(memberJpaEntity);
+        MemberJpaEntity encryptedMemberJpaEntity = MemberJpaEntity.from(member, cryptoProvider);
+        memberRepository.save(encryptedMemberJpaEntity);
     }
 
     @Override

--- a/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
+++ b/member-service/member-adapters/src/main/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapter.java
@@ -39,6 +39,8 @@ public class MemberPersistenceAdapter implements SignUpPort, FindMemberPort, Upd
     public void saveOauthMember(Member member) {
         MemberJpaEntity encryptedMemberJpaEntity = MemberJpaEntity.fromOauth(member, cryptoProvider);
         memberRepository.save(encryptedMemberJpaEntity);
+
+        member.setId(encryptedMemberJpaEntity.getId());
     }
 
     @Override

--- a/member-service/member-adapters/src/main/resources/application.yml
+++ b/member-service/member-adapters/src/main/resources/application.yml
@@ -32,6 +32,16 @@ spring:
       port: 8200
   jwt:
     secret: key
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: id
+            client-secret: secret
+            scope:
+              - email
+              - profile
   mvc:
     pathmatch:
       matching-strategy: ANT_PATH_MATCHER

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/cookie/CookieManagerTest.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/in/web/cookie/CookieManagerTest.java
@@ -1,0 +1,93 @@
+package personal.jeuksipay.member.adapter.in.web.cookie;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class CookieManagerTest {
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+
+    private static final String NAME = "testName";
+    private static final String VALUE = "testValue";
+    private static final int MAX_AGE = 3_600;
+
+    private static final Object ORIGINAL_OBJECT = "testObject";
+
+    @DisplayName("쿠키를 추가한다.")
+    @Test
+    void addCookie() {
+        // given
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+
+        // when
+        CookieManager.addCookie(response, NAME, VALUE, MAX_AGE);
+
+        // then
+        verify(response).addCookie(cookieCaptor.capture());
+
+        assertThat(cookieCaptor.getValue().getName()).isEqualTo(NAME);
+        assertThat(cookieCaptor.getValue().getValue()).isEqualTo(VALUE);
+        assertThat(cookieCaptor.getValue().getMaxAge()).isEqualTo(MAX_AGE);
+    }
+
+    @DisplayName("쿠키를 삭제한다.")
+    @Test
+    void deleteCookie() {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        Cookie existingCookie = new Cookie(NAME, VALUE);
+        existingCookie.setMaxAge(MAX_AGE);
+        Cookie[] cookies = {existingCookie};
+
+        when(request.getCookies()).thenReturn(cookies);
+
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+
+        // when
+        CookieManager.deleteCookie(request, response, NAME);
+
+        // then
+        verify(response).addCookie(cookieCaptor.capture());
+        Cookie modifiedCookie = cookieCaptor.getValue();
+
+        assertThat(modifiedCookie.getName()).isEqualTo(NAME);
+        assertThat(modifiedCookie.getValue()).isEmpty();
+        assertThat(modifiedCookie.getMaxAge()).isZero();
+    }
+
+    @DisplayName("쿠키값을 직렬화한다.")
+    @Test
+    void serialize() {
+        // given, when
+        String serializedObject = CookieManager.serialize(ORIGINAL_OBJECT);
+
+        // then
+        assertThat(serializedObject).isNotEqualTo(ORIGINAL_OBJECT);
+
+        Pattern base64Pattern = Pattern.compile("^[A-Za-z0-9+/]+={0,2}$");
+        assertThat(base64Pattern.matcher(serializedObject).matches()).isTrue();
+    }
+
+    @DisplayName("쿠키값을 역직렬화한다.")
+    @Test
+    void deserialize() {
+        // given
+        String serializedObject = CookieManager.serialize(ORIGINAL_OBJECT);
+        Cookie cookie = new Cookie(NAME, serializedObject);
+
+        // when
+        String deserializedObject = CookieManager.deserialize(cookie, String.class);
+
+        // then
+        assertThat(deserializedObject).isEqualTo(ORIGINAL_OBJECT);
+    }
+}

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapterTest.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapterTest.java
@@ -171,15 +171,15 @@ class MemberPersistenceAdapterTest {
     @DisplayName("이메일 주소를 통해 회원을 조회하고 최종 로그인 시간을 기록할 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com,  Abcd1234!, 홍길동, 01012345678, ROLE_GENERAL_USER",
-            "abcd@abcd.com,, Abcd12345!, 고길동, 01012345679, ROLE_BUSINESS_USER",
-            "abcd@abcde.com, Abcd123456!, 김길동, 01012345680, ROLE_ADMIN"
+            "abcd@abc.com, person1, Abcd1234!, 홍길동, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, Abcd12345!, 고길동, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, Abcd123456!, 김길동, 01012345680, ROLE_ADMIN"
     })
-    void findMemberByEmailOrUsername(String email, String password,
-                                     String fullName, String phone, String role) {
+    void findMemberByEmail(String email, String username, String password,
+                           String fullName, String phone, String role) {
         // given
         Member createdMember = MemberTestObjectFactory.createMember(
-                email, password, passwordEncoder, fullName, phone, List.of(role)
+                email, username, password, passwordEncoder, fullName, phone, List.of(role)
         );
         MemberJpaEntity memberJpaEntity = MemberJpaEntity.from(createdMember, cryptoProvider);
 

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapterTest.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/adapter/out/persistence/member/MemberPersistenceAdapterTest.java
@@ -75,6 +75,25 @@ class MemberPersistenceAdapterTest {
         assertThat(memberJpaEntity.getModifiedAt()).isEqualTo(member.getModifiedAt());
     }
 
+    @DisplayName("Oauth 회원 JPA 엔티티를 생성하고 데이터를 암호화 해 저장할 수 있다.")
+    @ParameterizedTest
+    @CsvSource({
+            "abcd@abc.com, person1", "abcd@abcd.com, person2", "abcd@abcde.com, person3"
+    })
+    void saveOauthMember(String oauthEmail, String oauthName) {
+        // given
+        Member member = MemberTestObjectFactory.createMember(oauthEmail, oauthName);
+
+        // when
+        memberPersistenceAdapter.saveOauthMember(member);
+        MemberJpaEntity memberJpaEntity = memberRepository.findById(member.getId()).get();
+
+        // then
+        assertThat(memberJpaEntity.getId()).isEqualTo(member.getId());
+        assertThat(memberJpaEntity.getEmail()).isEqualTo(member.getEmail().encrypt(cryptoProvider));
+        assertThat(memberJpaEntity.getOauthName()).isEqualTo(member.getOauthName().encrypt(cryptoProvider));
+    }
+
     @DisplayName("여러 권한을 가진 회원 JPA 엔티티를 생성하고 데이터를 암호화 해 저장할 수 있다.")
     @ParameterizedTest
     @CsvSource({
@@ -147,6 +166,38 @@ class MemberPersistenceAdapterTest {
         assertThatThrownBy(() -> memberPersistenceAdapter.findMemberById(memberJpaEntity.getId() + 1))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage(MEMEBER_ID_NOT_FOUND_EXCEPTION + (memberJpaEntity.getId() + 1));
+    }
+
+    @DisplayName("이메일 주소를 통해 회원을 조회하고 최종 로그인 시간을 기록할 수 있다.")
+    @ParameterizedTest
+    @CsvSource({
+            "abcd@abc.com,  Abcd1234!, 홍길동, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com,, Abcd12345!, 고길동, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, Abcd123456!, 김길동, 01012345680, ROLE_ADMIN"
+    })
+    void findMemberByEmailOrUsername(String email, String password,
+                                     String fullName, String phone, String role) {
+        // given
+        Member createdMember = MemberTestObjectFactory.createMember(
+                email, password, passwordEncoder, fullName, phone, List.of(role)
+        );
+        MemberJpaEntity memberJpaEntity = MemberJpaEntity.from(createdMember, cryptoProvider);
+
+        memberRepository.save(memberJpaEntity);
+
+        LocalDateTime beforeLogin = LocalDateTime.now().minusNanos(1);
+
+        // when
+        Member foundMember = memberPersistenceAdapter.findMemberByEmail(email);
+
+        // then
+        LocalDateTime afterLogin = LocalDateTime.now().plusNanos(1);
+
+        assertThat(foundMember.getEmail()).isEqualTo(Email.of(email));
+        assertThat(foundMember.getEmail()).isEqualTo(Email.of(email));
+
+        assertThat(memberJpaEntity.getLastLoggedInAt()).isAfter(beforeLogin);
+        assertThat(memberJpaEntity.getLastLoggedInAt()).isBefore(afterLogin);
     }
 
     @DisplayName("이메일 주소 또는 사용자 이름을 통해 회원을 조회하고 최종 로그인 시간을 기록할 수 있다.")

--- a/member-service/member-adapters/src/test/java/personal/jeuksipay/member/testutil/MemberTestObjectFactory.java
+++ b/member-service/member-adapters/src/test/java/personal/jeuksipay/member/testutil/MemberTestObjectFactory.java
@@ -56,6 +56,30 @@ public class MemberTestObjectFactory {
                 .build();
     }
 
+    public static Member createMember(String email, String oauthName) {
+        return Member.builder()
+                .email(Email.of(email))
+                .oauthName(OauthName.of(oauthName))
+                .build();
+    }
+
+    public static Member createMember(String email, String password, PasswordEncoder passwordEncoder,
+                                      String fullName, String phone, List<String> roles) {
+        return Member.builder()
+                .email(Email.of(email))
+                .password(Password.from(password, passwordEncoder))
+                .fullName(FullName.of(fullName))
+                .phone(Phone.of(phone))
+                .address(Address.builder()
+                        .city(CITY)
+                        .street(STREET)
+                        .zipcode(ZIPCODE)
+                        .detailedAddress(DETAILED_ADDRESS)
+                        .build())
+                .roles(Roles.from(roles))
+                .build();
+    }
+
     public static Member createMember(String email, String username, String password, PasswordEncoder passwordEncoder,
                                       String fullName, String phone, List<String> roles) {
         return Member.builder()

--- a/member-service/member-application/build.gradle
+++ b/member-service/member-application/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security:2.7.8'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.8'

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/usecase/OAuth2UserCustomUseCase.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/in/usecase/OAuth2UserCustomUseCase.java
@@ -1,0 +1,9 @@
+package personal.jeuksipay.member.application.port.in.usecase;
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public interface OAuth2UserCustomUseCase {
+    OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException;
+}

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/out/FindMemberPort.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/out/FindMemberPort.java
@@ -7,6 +7,8 @@ public interface FindMemberPort {
 
     Member findMemberByEmailOrUsername(String emailOrUsername);
 
+    Member findMemberByEmail(String oauthEmail);
+
     void checkDuplicateUsername(String username);
 
     void checkDuplicateEmail(String email);

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/out/SignUpPort.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/port/out/SignUpPort.java
@@ -4,4 +4,6 @@ import personal.jeuksipay.member.domain.Member;
 
 public interface SignUpPort {
     void saveMember(Member member);
+
+    void saveOauthMember(Member member);
 }

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/OAuth2UserCustomService.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/OAuth2UserCustomService.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import personal.jeuksipay.common.application.UseCase;
 import personal.jeuksipay.member.application.port.in.usecase.OAuth2UserCustomUseCase;
 import personal.jeuksipay.member.application.port.out.FindMemberPort;
 import personal.jeuksipay.member.application.port.out.SignUpPort;
@@ -16,7 +17,7 @@ import javax.persistence.EntityNotFoundException;
 import java.util.Map;
 
 @RequiredArgsConstructor
-@Service
+@UseCase
 public class OAuth2UserCustomService extends DefaultOAuth2UserService implements OAuth2UserCustomUseCase {
     private final FindMemberPort findMemberPort;
     private final UpdateMemberPort updateMemberPort;

--- a/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/OAuth2UserCustomService.java
+++ b/member-service/member-application/src/main/java/personal/jeuksipay/member/application/service/OAuth2UserCustomService.java
@@ -1,0 +1,53 @@
+package personal.jeuksipay.member.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import personal.jeuksipay.member.application.port.in.usecase.OAuth2UserCustomUseCase;
+import personal.jeuksipay.member.application.port.out.FindMemberPort;
+import personal.jeuksipay.member.application.port.out.SignUpPort;
+import personal.jeuksipay.member.application.port.out.UpdateMemberPort;
+import personal.jeuksipay.member.domain.Member;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class OAuth2UserCustomService extends DefaultOAuth2UserService implements OAuth2UserCustomUseCase {
+    private final FindMemberPort findMemberPort;
+    private final UpdateMemberPort updateMemberPort;
+    private final SignUpPort signUpPort;
+
+    private static final String OAUTH_EMAIL_ATTRIBUTE = "email";
+    private static final String OAUTH_NAME_ATTRIBUTE = "name";
+
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        saveOrUpdate(oAuth2User);
+
+        return oAuth2User;
+    }
+
+    private void saveOrUpdate(OAuth2User oAuth2User) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String oauthEmail = (String) attributes.get(OAUTH_EMAIL_ATTRIBUTE);
+        String oauthName = (String) attributes.get(OAUTH_NAME_ATTRIBUTE);
+
+        try {
+            Member member = findMemberPort.findMemberByEmail(oauthEmail);
+            member.updateOauthName(oauthName);
+            updateMemberPort.updateMember(member);
+        } catch (EntityNotFoundException e) {
+            Member member = Member.of(oauthEmail, oauthName);
+            signUpPort.saveOauthMember(member);
+        }
+    }
+}
+

--- a/member-service/member-domain/src/main/java/personal/jeuksipay/member/domain/Member.java
+++ b/member-service/member-domain/src/main/java/personal/jeuksipay/member/domain/Member.java
@@ -15,6 +15,7 @@ public class Member {
     private Email email;
     private final Username username;
     private Password password;
+    private OauthName oauthName;
     private final FullName fullName;
     private Phone phone;
     private Address address;
@@ -24,13 +25,14 @@ public class Member {
     private LocalDateTime lastLoggedInAt;
 
     @Builder
-    private Member(Long id, Email email, Username username, Password password,
+    private Member(Long id, Email email, Username username, Password password, OauthName oauthName,
                    FullName fullName, Phone phone, Address address, Roles roles,
                    LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime lastLoggedInAt) {
         this.id = id;
         this.email = email;
         this.username = username;
         this.password = password;
+        this.oauthName = oauthName;
         this.fullName = fullName;
         this.phone = phone;
         this.address = address;
@@ -40,21 +42,31 @@ public class Member {
         this.lastLoggedInAt = lastLoggedInAt;
     }
 
+    public static Member of(String oauthEmail, String oauthName) {
+        return Member.builder()
+                .email(Email.of(oauthEmail))
+                .oauthName(OauthName.of(oauthName))
+                .build();
+    }
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Member member = (Member) o;
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        Member member = (Member) object;
         return Objects.equals(id, member.id) && Objects.equals(email, member.email)
                 && Objects.equals(username, member.username) && Objects.equals(password, member.password)
-                && Objects.equals(fullName, member.fullName) && Objects.equals(phone, member.phone)
-                && Objects.equals(address, member.address) && Objects.equals(roles, member.roles)
-                && Objects.equals(createdAt, member.createdAt) && Objects.equals(modifiedAt, member.modifiedAt);
+                && Objects.equals(oauthName, member.oauthName) && Objects.equals(fullName, member.fullName)
+                && Objects.equals(phone, member.phone) && Objects.equals(address, member.address)
+                && Objects.equals(roles, member.roles) && Objects.equals(createdAt, member.createdAt)
+                && Objects.equals(modifiedAt, member.modifiedAt)
+                && Objects.equals(lastLoggedInAt, member.lastLoggedInAt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, email, username, password, fullName, phone, address, roles, createdAt, modifiedAt);
+        return Objects.hash(id, email, username, password, oauthName,
+                fullName, phone, address, roles, createdAt, modifiedAt, lastLoggedInAt);
     }
 
     public void setId(Long id) {
@@ -77,6 +89,11 @@ public class Member {
 
     public void updatePassword(String passwordToChange, PasswordEncoder passwordEncoder) {
         this.password = Password.from(passwordToChange, passwordEncoder);
+        modifiedAt = LocalDateTime.now();
+    }
+
+    public void updateOauthName(String oauthName) {
+        this.oauthName = OauthName.of(oauthName);
         modifiedAt = LocalDateTime.now();
     }
 }

--- a/member-service/member-domain/src/main/java/personal/jeuksipay/member/domain/wrapper/OauthName.java
+++ b/member-service/member-domain/src/main/java/personal/jeuksipay/member/domain/wrapper/OauthName.java
@@ -1,0 +1,56 @@
+package personal.jeuksipay.member.domain.wrapper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import personal.jeuksipay.member.domain.security.CryptoProvider;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Objects;
+
+public class OauthName {
+    private final String oauthName;
+
+    private OauthName(String oauthName) {
+        this.oauthName = oauthName;
+    }
+
+    @JsonCreator
+    public static OauthName of(@JsonProperty("oauthName") String oauthName) {
+        return new OauthName(oauthName);
+    }
+
+    public OauthName encrypt(CryptoProvider cryptoProvider) {
+        return new OauthName(cryptoProvider.encrypt(oauthName));
+    }
+
+    public OauthName decrypt(CryptoProvider cryptoProvider) {
+        return new OauthName(cryptoProvider.decrypt(oauthName));
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        OauthName oauthName1 = (OauthName) object;
+        return Objects.equals(oauthName, oauthName1.oauthName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oauthName);
+    }
+
+    @Converter
+    public static class OauthNameConverter implements AttributeConverter<OauthName, String> {
+        @Override
+        public String convertToDatabaseColumn(OauthName oauthName) {
+            return oauthName == null ? null : oauthName.oauthName;
+        }
+
+        @Override
+        public OauthName convertToEntityAttribute(String oauthName) {
+            return oauthName == null ? null : new OauthName(oauthName);
+        }
+    }
+}

--- a/member-service/member-domain/src/test/java/personal/jeuksipay/member/MemberTestConstant.java
+++ b/member-service/member-domain/src/test/java/personal/jeuksipay/member/MemberTestConstant.java
@@ -7,6 +7,9 @@ public class MemberTestConstant {
     public static final String USERNAME2 = "person2";
     public static final String PASSWORD1 = "Abcd1234!";
     public static final String PASSWORD2 = "Abcd12345!";
+
+    public static final String OAUTH_NAME1 = "oauth1";
+    public static final String OAUTH_NAME2 = "oauth2";
     ;
     public static final String FULL_NAME1 = "홍길동";
     public static final String FULL_NAME2 = "고길동";

--- a/member-service/member-domain/src/test/java/personal/jeuksipay/member/domain/wrapper/OauthNameTest.java
+++ b/member-service/member-domain/src/test/java/personal/jeuksipay/member/domain/wrapper/OauthNameTest.java
@@ -1,0 +1,35 @@
+package personal.jeuksipay.member.domain.wrapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static personal.jeuksipay.member.MemberTestConstant.OAUTH_NAME1;
+import static personal.jeuksipay.member.MemberTestConstant.OAUTH_NAME2;
+
+class OauthNameTest {
+    @DisplayName("동일한 OauthName을 전송하면 동등한 OauthName 인스턴스를 생성한다.")
+    @Test
+    void ofSameValue() {
+        // given, when
+        OauthName oauthName1 = OauthName.of(OAUTH_NAME1);
+        OauthName oauthName2 = OauthName.of(OAUTH_NAME1);
+
+        // then
+        assertThat(oauthName1).isEqualTo(oauthName2);
+        assertThat(oauthName1.hashCode()).isEqualTo(oauthName2.hashCode());
+    }
+
+    @DisplayName("다른 OauthName을 전송하면 동등하지 않은 OauthName 인스턴스를 생성한다.")
+    @Test
+    void ofDifferentValue() {
+        // given, when
+        OauthName oauthName1 = OauthName.of(OAUTH_NAME1);
+        OauthName oauthName2 = OauthName.of(OAUTH_NAME2);
+
+
+        // then
+        assertThat(oauthName1).isNotEqualTo(oauthName2);
+        assertThat(oauthName1.hashCode()).isNotEqualTo(oauthName2.hashCode());
+    }
+}


### PR DESCRIPTION
## resolve #48

## 추가사항

### 의존성 설정
- OAuth 의존성

### 애플리케이션 설정
- 클라이언트 ID 추가
- 클라이언트 비밀번호 추가

### OAuth 인증을 위한 쿠키 관리 클래스 추가

#### 프로덕션 코드
- 쿠키 추가 기능
- 쿠키 삭제 기능
- 쿠키값 직렬화 기능
- 쿠키값 역직렬화 기능

#### 테스트 코드
- 쿠키 추가 기능
- 쿠키 삭제 기능
- 쿠키값 직렬화 기능
- 쿠키값 역직렬화 기능

### Oauth2 회원정보 저장 기능

#### 프로덕션 코드
- Oauth2 가입 회원 저장 기능 추가
- 이메일을 통한 회원 정보 검색 기능 추가
- Member 클래스에 OauthName 필드 추가
- MemberJpaEntity 클래스에 OauthName 속성 추가